### PR TITLE
Fixed Makefile with the proper place for LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ CC=gcc
 .PHONY: all
 all: test
 
+test: test.c
+	$(CC) $(CFLAGS) test.c -o test $(LDFLAGS)
+
 .PHONY: clean
 clean:
 	rm -f test


### PR DESCRIPTION
This PR fixes the issue which was found during the test application build. The proper order of the compiler options should be:
```compiler - options - source file - object file -linker flags```